### PR TITLE
CRAB-42252: Create custom teamcity agent image that uses 22.04 base image

### DIFF
--- a/checks/linux-local/docker-compose.yml
+++ b/checks/linux-local/docker-compose.yml
@@ -1,23 +1,23 @@
 version: '2'
 services:
-  teamcity-server:
-    image: teamcity-server:local-linux
-    ports:
-     - "8112:8111"
- 
+  #  teamcity-server:
+  #    image: teamcity-server:local-linux
+  #    ports:
+  #      - "8112:8111"
+
   teamcity-minimal-agent:
-    image: teamcity-minimal-agent:local-linux
+    image: teamcity-minimal-agent:EAP-linux
     environment:
       - SERVER_URL=teamcity-server:8111
 
   teamcity-agent:
-    image: teamcity-agent:local-linux
+    image: teamcity-agent:EAP-linux
     environment:
       - SERVER_URL=teamcity-server:8111
 
-  teamcity-agent-sudo:
-    image: teamcity-agent:local-linux-sudo
-    privileged: true
-    environment:
-      - SERVER_URL=teamcity-server:8111
-      - DOCKER_IN_DOCKER=start
+#  teamcity-agent-sudo:
+#    image: teamcity-agent:local-linux-sudo
+#    privileged: true
+#    environment:
+#      - SERVER_URL=teamcity-server:8111
+#      - DOCKER_IN_DOCKER=start

--- a/configs/linux/MinimalAgent/Ubuntu/20.04/Ubuntu.Dockerfile.config
+++ b/configs/linux/MinimalAgent/Ubuntu/20.04/Ubuntu.Dockerfile.config
@@ -1,4 +1,4 @@
 linuxVersion=
 repo=https://hub.docker.com/r/jetbrains/
 # https://hub.docker.com/_/ubuntu/
-ubuntuImage=ubuntu:20.04
+ubuntuImage=ubuntu:22.04

--- a/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/Agent/Ubuntu/20.04/Dockerfile
@@ -1,11 +1,11 @@
 # Default arguments
 ARG containerdIoLinuxComponentVersion='1.6.28-2'
 ARG dockerLinuxComponentVersion='5:24.0.9-1~ubuntu'
-ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g'
+ARG dotnetLibs='libc6 libgcc1 libgssapi-krb5-2 libicu70 libssl3 libstdc++6 zlib1g'
 ARG dotnetLinuxComponent='https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.413/dotnet-sdk-6.0.413-linux-x64.tar.gz'
 ARG dotnetLinuxComponentSHA512='ee0a77d54e6d4917be7310ff0abb3bad5525bfb4beb1db0c215e65f64eb46511f5f12d6c7ff465a1d4ab38577e6a1950fde479ee94839c50e627020328a702de'
-ARG gitLFSLinuxComponentVersion='2.9.2-1'
-ARG gitLinuxComponentVersion='1:2.43.2-0ppa1~ubuntu20.04.1'
+ARG gitLFSLinuxComponentVersion='3.0.2-1ubuntu0.2'  # Updated to the latest version for Ubuntu 22.04
+ARG gitLinuxComponentVersion='1:2.43.2-0ppa1~ubuntu22.04.1'  # updated the base to ubuntu 22.04
 ARG p4Version='2022.2-2531894'
 ARG repo='https://hub.docker.com/r/jetbrains/'
 ARG teamcityMinimalAgentImage='teamcity-minimal-agent:EAP-linux'
@@ -57,7 +57,7 @@ ARG containerdIoLinuxComponentVersion
 ARG p4Version
 
 RUN apt-get update && \
-    apt-get install -y mercurial apt-transport-https software-properties-common && \
+    apt-get install -y xz-utils mercurial apt-transport-https software-properties-common && \
     add-apt-repository ppa:git-core/ppa -y && \
     apt-get install -y git=${gitLinuxComponentVersion} git-lfs=${gitLFSLinuxComponentVersion} && \
     git lfs install --system && \

--- a/context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile
+++ b/context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile
@@ -1,7 +1,7 @@
 # Default arguments
 ARG jdkLinuxComponent='https://corretto.aws/downloads/resources/17.0.7.7.1/amazon-corretto-17.0.7.7.1-linux-x64.tar.gz'
 ARG jdkLinuxComponentMD5SUM='443750a02c28ff2807c80032ee2e8ebc'
-ARG ubuntuImage='ubuntu:20.04'
+ARG ubuntuImage='ubuntu:22.04'
 
 # The list of required arguments
 # ARG jdkLinuxComponent

--- a/context/generated/teamcity-agent-EAP-linux-sudo.cmd
+++ b/context/generated/teamcity-agent-EAP-linux-sudo.cmd
@@ -1,5 +1,5 @@
 cd ../..
-docker pull ubuntu:20.04
+docker pull ubuntu:22.04
 echo TeamCity/webapps > context/.dockerignore
 echo TeamCity/devPackage >> context/.dockerignore
 echo TeamCity/lib >> context/.dockerignore

--- a/context/generated/teamcity-agent-EAP-linux-sudo.sh
+++ b/context/generated/teamcity-agent-EAP-linux-sudo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 cd ../..
-docker pull ubuntu:20.04
+docker pull ubuntu:22.04
 echo TeamCity/webapps > context/.dockerignore
 echo TeamCity/devPackage >> context/.dockerignore
 echo TeamCity/lib >> context/.dockerignore

--- a/context/generated/teamcity-agent-EAP-linux.cmd
+++ b/context/generated/teamcity-agent-EAP-linux.cmd
@@ -1,5 +1,5 @@
 cd ../..
-docker pull ubuntu:20.04
+docker pull ubuntu:22.04
 echo TeamCity/webapps > context/.dockerignore
 echo TeamCity/devPackage >> context/.dockerignore
 echo TeamCity/lib >> context/.dockerignore

--- a/context/generated/teamcity-agent-EAP-linux.sh
+++ b/context/generated/teamcity-agent-EAP-linux.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 cd ../..
-docker pull ubuntu:20.04
+docker pull ubuntu:22.04
 echo TeamCity/webapps > context/.dockerignore
 echo TeamCity/devPackage >> context/.dockerignore
 echo TeamCity/lib >> context/.dockerignore
-docker build -f "context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile" -t teamcity-minimal-agent:EAP-linux "context"
+docker build -f "context/generated/linux/MinimalAgent/Ubuntu/20.04/Dockerfile" -t teamcity-minimal-agent:EAP-linux "context" --platform=linux/amd64
 echo 2> context/.dockerignore
 echo TeamCity >> context/.dockerignore
-docker build -f "context/generated/linux/Agent/Ubuntu/20.04/Dockerfile" -t teamcity-agent:EAP-linux "context"
+docker build -f "context/generated/linux/Agent/Ubuntu/20.04/Dockerfile" -t teamcity-agent:EAP-linux "context" --platform=linux/amd64

--- a/context/generated/teamcity-agent.md
+++ b/context/generated/teamcity-agent.md
@@ -103,7 +103,7 @@ Container platform: linux
 Docker build commands:
 
 ```
-docker pull ubuntu:20.04
+docker pull ubuntu:22.04
 echo TeamCity/webapps > context/.dockerignore
 echo TeamCity/devPackage >> context/.dockerignore
 echo TeamCity/lib >> context/.dockerignore
@@ -221,7 +221,7 @@ Container platform: linux
 Docker build commands:
 
 ```
-docker pull ubuntu:20.04
+docker pull ubuntu:22.04
 echo TeamCity/webapps > context/.dockerignore
 echo TeamCity/devPackage >> context/.dockerignore
 echo TeamCity/lib >> context/.dockerignore

--- a/context/generated/teamcity-minimal-agent-EAP-linux.cmd
+++ b/context/generated/teamcity-minimal-agent-EAP-linux.cmd
@@ -1,5 +1,5 @@
 cd ../..
-docker pull ubuntu:20.04
+docker pull ubuntu:22.04
 echo TeamCity/webapps > context/.dockerignore
 echo TeamCity/devPackage >> context/.dockerignore
 echo TeamCity/lib >> context/.dockerignore

--- a/context/generated/teamcity-minimal-agent-EAP-linux.sh
+++ b/context/generated/teamcity-minimal-agent-EAP-linux.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 cd ../..
-docker pull ubuntu:20.04
+docker pull ubuntu:22.04
 echo TeamCity/webapps > context/.dockerignore
 echo TeamCity/devPackage >> context/.dockerignore
 echo TeamCity/lib >> context/.dockerignore

--- a/context/generated/teamcity-minimal-agent.md
+++ b/context/generated/teamcity-minimal-agent.md
@@ -72,7 +72,7 @@ Container platform: linux
 Docker build commands:
 
 ```
-docker pull ubuntu:20.04
+docker pull ubuntu:22.04
 echo TeamCity/webapps > context/.dockerignore
 echo TeamCity/devPackage >> context/.dockerignore
 echo TeamCity/lib >> context/.dockerignore


### PR DESCRIPTION
Used [teamcity-docker-images](https://github.com/seeq12/teamcity-docker-images?tab=readme-ov-file#to-amend-current-docker-images-or-to-build-your-custom-docker-images-or-create-a-pull-request) instructions as a guide to generate a new teamcity agent image that uses Ubuntu 22.04 to resolve the following build errors:

https://seeq.atlassian.net/browse/CRAB-42223
https://seeq.atlassian.net/browse/CRAB-42245
https://seeq.atlassian.net/browse/CRAB-42247

Created a repo called [seeq13/teamcity-agent ](https://hub.docker.com/repository/docker/seeq13/teamcity-agent/general)

Built image then tagged it as seeq13/teamcity-agent:ubuntu-2204  and pushed it to DockerHub.